### PR TITLE
Allow map root backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ addons:
 
 jobs:
   include:
-#    - os: linux
-#      dist: focal
-#      env:
-#        - RUN_TYPE=coverage
-#        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11"
+    - os: linux
+      dist: focal
+      env:
+        - RUN_TYPE=coverage
+        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11"
     - os: linux
       dist: focal
       env:

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,7 +4,7 @@ sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31
    sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install clang-11 llvm-11 -o Debug::pkgProblemResolver=yes
 
 if [ "$RUN_TYPE" = "coverage" ]; then
-   sudo apt-get install -y lcov ruby
+   sudo apt-get install -y lcov ruby valgrind
    sudo gem install coveralls-lcov
 fi
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,7 +3,9 @@
 set -e
 set -x
 
-#if [ "$RUN_TYPE" = "test" ]; then
-#   cd $(dirname "$0")/../build/tests
-#   exec ctest -j3 --output-on-failure
-#fi
+cd $(dirname "$0")/../build/tests
+if [ "$RUN_TYPE" = "test" ]; then
+   exec ctest -j3 --output-on-failure && ../libraries/vendor/mira/test/mira_test
+elif [ "$RUN_TYPE" = "coverage" ]; then
+   exec valgrind --error-exitcode=1 --leak-check=yes ./koinos_tests
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,7 +5,7 @@ set -x
 
 cd $(dirname "$0")/../build/tests
 if [ "$RUN_TYPE" = "test" ]; then
-   exec ctest -j3 --output-on-failure && ../libraries/vendor/mira/test/mira_test
+   exec ctest -j3 --output-on-failure
 elif [ "$RUN_TYPE" = "coverage" ]; then
-   exec valgrind --error-exitcode=1 --leak-check=yes ./koinos_tests
+   exec valgrind --error-exitcode=1 --leak-check=yes ./koinos_state_db_tests
 fi

--- a/libraries/state_db/backends/backend.cpp
+++ b/libraries/state_db/backends/backend.cpp
@@ -2,6 +2,10 @@
 
 namespace koinos::state_db::backends {
 
+abstract_backend::abstract_backend() :
+   _id( crypto::multihash::zero( crypto::multicodec::sha2_256 ) )
+{}
+
 bool abstract_backend::empty() const
 {
    return size() == 0;

--- a/libraries/state_db/backends/backend.cpp
+++ b/libraries/state_db/backends/backend.cpp
@@ -7,4 +7,44 @@ bool abstract_backend::empty() const
    return size() == 0;
 }
 
+abstract_backend::size_type abstract_backend::revision() const
+{
+   return _revision;
+}
+
+void abstract_backend::set_revision( abstract_backend::size_type revision )
+{
+   _revision = revision;
+}
+
+const crypto::multihash& abstract_backend::id() const
+{
+   return _id;
+}
+
+void abstract_backend::set_id( const crypto::multihash& id )
+{
+   _id = id;
+}
+
+const crypto::multihash& abstract_backend::merkle_root() const
+{
+   return _merkle_root;
+}
+
+void abstract_backend::set_merkle_root( const crypto::multihash& merkle_root )
+{
+   _merkle_root = merkle_root;
+}
+
+const protocol::block_header& abstract_backend::block_header() const
+{
+   return _header;
+}
+
+void abstract_backend::set_block_header( const protocol::block_header& header )
+{
+   _header = header;
+}
+
 } // koinos::state_db::backends

--- a/libraries/state_db/backends/map/map_backend.cpp
+++ b/libraries/state_db/backends/map/map_backend.cpp
@@ -57,14 +57,10 @@ iterator map_backend::lower_bound( const key_type& k )
    return iterator( std::make_unique< map_iterator >( std::make_unique< map_iterator::iterator_impl >( _map.lower_bound( k ) ), _map ) );
 }
 
-const protocol::block_header& map_backend::block_header() const
-{
-   return _header;
-}
+void map_backend::start_write_batch() {}
 
-void map_backend::set_block_header( const protocol::block_header& header )
-{
-   _header = header;
-}
+void map_backend::end_write_batch() {}
+
+void map_backend::store_metadata() {}
 
 } // koinos::state_db::backends::map

--- a/libraries/state_db/backends/map/map_backend.cpp
+++ b/libraries/state_db/backends/map/map_backend.cpp
@@ -63,4 +63,9 @@ void map_backend::end_write_batch() {}
 
 void map_backend::store_metadata() {}
 
+std::shared_ptr< abstract_backend > map_backend::clone() const
+{
+   return std::make_shared< map_backend >( *this );
+}
+
 } // koinos::state_db::backends::map

--- a/libraries/state_db/backends/rocksdb/rocksdb_backend.cpp
+++ b/libraries/state_db/backends/rocksdb/rocksdb_backend.cpp
@@ -237,44 +237,6 @@ void rocksdb_backend::end_write_batch()
    }
 }
 
-rocksdb_backend::size_type rocksdb_backend::revision() const
-{
-   KOINOS_ASSERT( _db, rocksdb_database_not_open_exception, "database not open" );
-
-   return _revision;
-}
-
-void rocksdb_backend::set_revision( size_type rev )
-{
-   KOINOS_ASSERT( _db, rocksdb_database_not_open_exception, "database not open" );
-
-   _revision = rev;
-}
-
-const crypto::multihash& rocksdb_backend::id() const
-{
-   KOINOS_ASSERT( _db, rocksdb_database_not_open_exception, "database not open" );
-
-   return _id;
-}
-
-void rocksdb_backend::set_id( const crypto::multihash& id )
-{
-   KOINOS_ASSERT( _db, rocksdb_database_not_open_exception, "database not open" );
-
-   _id = id;
-}
-
-const crypto::multihash& rocksdb_backend::merkle_root() const
-{
-   return _merkle_root;
-}
-
-void rocksdb_backend::set_merkle_root( const crypto::multihash& merkle_root )
-{
-   _merkle_root = merkle_root;
-}
-
 iterator rocksdb_backend::begin()
 {
    KOINOS_ASSERT( _db, rocksdb_database_not_open_exception, "database not open" );
@@ -439,16 +401,6 @@ iterator rocksdb_backend::lower_bound( const key_type& k )
    return iterator( std::unique_ptr< abstract_iterator >( std::move( itr ) ) );
 }
 
-const protocol::block_header& rocksdb_backend::block_header() const
-{
-   return _header;
-}
-
-void rocksdb_backend::set_block_header( const protocol::block_header& header )
-{
-   _header = header;
-}
-
 void rocksdb_backend::load_metadata()
 {
    KOINOS_ASSERT( _db, rocksdb_database_not_open_exception, "database not open" );
@@ -472,7 +424,7 @@ void rocksdb_backend::load_metadata()
 
    KOINOS_ASSERT( status.ok(), rocksdb_read_exception, "unable to read from rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
 
-   _revision = util::converter::to< size_type >( value );
+   set_revision( util::converter::to< size_type >( value ) );
 
    status = _db->Get(
       *_ropts,
@@ -482,7 +434,7 @@ void rocksdb_backend::load_metadata()
 
    KOINOS_ASSERT( status.ok(), rocksdb_read_exception, "unable to read from rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
 
-   _id = util::converter::to< crypto::multihash >( value );
+   set_id( util::converter::to< crypto::multihash >( value ) );
 
    status = _db->Get(
       *_ropts,
@@ -492,7 +444,7 @@ void rocksdb_backend::load_metadata()
 
    KOINOS_ASSERT( status.ok(), rocksdb_read_exception, "unable to read from rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
 
-   _merkle_root = util::converter::to< crypto::multihash >( value );
+   set_merkle_root( util::converter::to< crypto::multihash >( value ) );
 
    status = _db->Get(
       *_ropts,
@@ -502,7 +454,7 @@ void rocksdb_backend::load_metadata()
 
    KOINOS_ASSERT( status.ok(), rocksdb_read_exception, "unable to read from rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
 
-   _header = util::converter::to< protocol::block_header >( value );
+   set_block_header( util::converter::to< protocol::block_header >( value ) );
 }
 
 void rocksdb_backend::store_metadata()
@@ -522,7 +474,7 @@ void rocksdb_backend::store_metadata()
       _wopts,
       &*_handles[ constants::metadata_column_index ],
       ::rocksdb::Slice( constants::revision_key ),
-      ::rocksdb::Slice( util::converter::as< std::string >( _revision ) )
+      ::rocksdb::Slice( util::converter::as< std::string >( revision() ) )
    );
 
    KOINOS_ASSERT( status.ok(), rocksdb_write_exception, "unable to write to rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
@@ -531,7 +483,7 @@ void rocksdb_backend::store_metadata()
       _wopts,
       &*_handles[ constants::metadata_column_index ],
       ::rocksdb::Slice( constants::id_key ),
-      ::rocksdb::Slice( util::converter::as< std::string >( _id ) )
+      ::rocksdb::Slice( util::converter::as< std::string >( id() ) )
    );
 
    KOINOS_ASSERT( status.ok(), rocksdb_write_exception, "unable to write to rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
@@ -540,7 +492,7 @@ void rocksdb_backend::store_metadata()
       _wopts,
       &*_handles[ constants::metadata_column_index ],
       ::rocksdb::Slice( constants::merkle_root_key ),
-      ::rocksdb::Slice( util::converter::as< std::string >( _merkle_root ) )
+      ::rocksdb::Slice( util::converter::as< std::string >( merkle_root() ) )
    );
 
    KOINOS_ASSERT( status.ok(), rocksdb_write_exception, "unable to write to rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
@@ -549,7 +501,7 @@ void rocksdb_backend::store_metadata()
       _wopts,
       &*_handles[ constants::metadata_column_index ],
       ::rocksdb::Slice( constants::block_header_key ),
-      ::rocksdb::Slice( util::converter::as< std::string >( _header ) )
+      ::rocksdb::Slice( util::converter::as< std::string >( block_header() ) )
    );
 
    KOINOS_ASSERT( status.ok(), rocksdb_write_exception, "unable to write to rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );

--- a/libraries/state_db/backends/rocksdb/rocksdb_backend.cpp
+++ b/libraries/state_db/backends/rocksdb/rocksdb_backend.cpp
@@ -507,4 +507,9 @@ void rocksdb_backend::store_metadata()
    KOINOS_ASSERT( status.ok(), rocksdb_write_exception, "unable to write to rocksdb database" + ( status.getState() ? ", " + std::string( status.getState() ) : "" ) );
 }
 
+std::shared_ptr< abstract_backend > rocksdb_backend::clone() const
+{
+   KOINOS_THROW( internal_exception, "rocksdb_backend, 'clone' not implemented" );
+}
+
 } // koinos::state_db::backends::rocksdb

--- a/libraries/state_db/detail/state_delta.cpp
+++ b/libraries/state_db/detail/state_delta.cpp
@@ -7,14 +7,22 @@ namespace koinos::state_db::detail {
 using backend_type = state_delta::backend_type;
 using value_type   = state_delta::value_type;
 
-state_delta::state_delta( const std::filesystem::path& p )
+state_delta::state_delta( const std::optional< std::filesystem::path >& p )
 {
-   auto backend = std::make_shared< backends::rocksdb::rocksdb_backend >();
-   backend->open( p );
-   _revision = backend->revision();
-   _id = backend->id();
-   _merkle_root =  backend->merkle_root();
-   _backend = backend;
+   if ( p )
+   {
+      auto backend = std::make_shared< backends::rocksdb::rocksdb_backend >();
+      backend->open( *p );
+      _backend = backend;
+   }
+   else
+   {
+      _backend = std::make_shared< backends::map::map_backend >();
+   }
+
+   _revision = _backend->revision();
+   _id = _backend->id();
+   _merkle_root =  _backend->merkle_root();
 }
 
 void state_delta::put( const key_type& k, const value_type& v )

--- a/libraries/state_db/detail/state_delta.cpp
+++ b/libraries/state_db/detail/state_delta.cpp
@@ -103,7 +103,7 @@ void state_delta::commit()
    node_stack.pop_back();
 
    // Start the write batch
-   std::static_pointer_cast< backends::rocksdb::rocksdb_backend >( backend )->start_write_batch();
+   backend->start_write_batch();
 
    // While there are nodes on the stack, write them to the backend
    while ( node_stack.size() )
@@ -125,13 +125,13 @@ void state_delta::commit()
 
    // Update metadata on the backend
    backend->set_block_header( block_header() );
-   std::static_pointer_cast< backends::rocksdb::rocksdb_backend >( backend )->set_revision( _revision );
-   std::static_pointer_cast< backends::rocksdb::rocksdb_backend >( backend )->set_id( _id );
-   std::static_pointer_cast< backends::rocksdb::rocksdb_backend >( backend )->set_merkle_root( merkle_root() );
-   std::static_pointer_cast< backends::rocksdb::rocksdb_backend >( backend )->store_metadata();
+   backend->set_revision( _revision );
+   backend->set_id( _id );
+   backend->set_merkle_root( merkle_root() );
+   backend->store_metadata();
 
    // End the write batch making the entire merge atomic
-   std::static_pointer_cast< backends::rocksdb::rocksdb_backend >( backend )->end_write_batch();
+   backend->end_write_batch();
 
    // Reset local variables to match new status as root delta
    _removed_objects.clear();
@@ -173,7 +173,7 @@ void state_delta::set_revision( uint64_t revision )
    _revision = revision;
    if ( is_root() )
    {
-      std::static_pointer_cast< backends::rocksdb::rocksdb_backend >( _backend )->set_revision( revision );
+      _backend->set_revision( revision );
    }
 }
 

--- a/libraries/state_db/detail/state_delta.cpp
+++ b/libraries/state_db/detail/state_delta.cpp
@@ -259,6 +259,31 @@ std::shared_ptr< state_delta > state_delta::make_child( const state_node_id& id,
    return child;
 }
 
+std::shared_ptr< state_delta > state_delta::clone( const state_node_id& id, const protocol::block_header& header )
+{
+   auto new_node = std::make_shared< state_delta >();
+   new_node->_parent = _parent;
+   new_node->_backend = _backend->clone();
+   new_node->_removed_objects = _removed_objects;
+
+   new_node->_id = id;
+   new_node->_revision = _revision;
+   new_node->_merkle_root = _merkle_root;
+
+   new_node->_finalized = _finalized;
+
+   new_node->_backend->set_id( id );
+   new_node->_backend->set_revision( _revision );
+   new_node->_backend->set_block_header( header );
+
+   if ( _merkle_root )
+   {
+      new_node->_backend->set_merkle_root( *_merkle_root );
+   }
+
+   return new_node;
+}
+
 const std::shared_ptr< backend_type > state_delta::backend() const
 {
    return _backend;

--- a/libraries/state_db/include/koinos/state_db/backends/backend.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/backend.hpp
@@ -48,6 +48,8 @@ class abstract_backend
 
       virtual void store_metadata() = 0;
 
+      virtual std::shared_ptr< abstract_backend > clone() const = 0;
+
    private:
       size_type              _revision = 0;
       crypto::multihash      _id;

--- a/libraries/state_db/include/koinos/state_db/backends/backend.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/backend.hpp
@@ -2,6 +2,7 @@
 
 #include <koinos/state_db/backends/iterator.hpp>
 
+#include <koinos/crypto/multihash.hpp>
 #include <koinos/protocol/protocol.pb.h>
 
 namespace koinos::state_db::backends {
@@ -29,8 +30,28 @@ class abstract_backend
       virtual iterator find( const key_type& k ) = 0;
       virtual iterator lower_bound( const key_type& k ) = 0;
 
-      virtual const protocol::block_header& block_header() const = 0;
-      virtual void set_block_header( const protocol::block_header& ) = 0;
+      size_type revision() const;
+      void set_revision( size_type );
+
+      const crypto::multihash& id() const;
+      void set_id( const crypto::multihash& );
+
+      const crypto::multihash& merkle_root() const;
+      void set_merkle_root( const crypto::multihash& );
+
+      const protocol::block_header& block_header() const;
+      void set_block_header( const protocol::block_header& );
+
+      virtual void start_write_batch() = 0;
+      virtual void end_write_batch() = 0;
+
+      virtual void store_metadata() = 0;
+
+   private:
+      size_type              _revision = 0;
+      crypto::multihash      _id;
+      crypto::multihash      _merkle_root;
+      protocol::block_header _header;
 };
 
 } // koinos::state_db::backends

--- a/libraries/state_db/include/koinos/state_db/backends/backend.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/backend.hpp
@@ -14,6 +14,7 @@ class abstract_backend
       using value_type = detail::value_type;
       using size_type  = detail::size_type;
 
+      abstract_backend();
       virtual ~abstract_backend() {};
 
       virtual iterator begin() = 0;

--- a/libraries/state_db/include/koinos/state_db/backends/exceptions.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/exceptions.hpp
@@ -5,5 +5,6 @@ namespace koinos::state_db::backends {
 
 KOINOS_DECLARE_DERIVED_EXCEPTION( backend_exception, state_db_exception );
 KOINOS_DECLARE_DERIVED_EXCEPTION( iterator_exception, state_db_exception );
+KOINOS_DECLARE_DERIVED_EXCEPTION( internal_exception, state_db_exception );
 
 } // koinos::state_db::backends

--- a/libraries/state_db/include/koinos/state_db/backends/map/map_backend.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/map/map_backend.hpp
@@ -35,6 +35,8 @@ class map_backend final : public abstract_backend {
 
       virtual void store_metadata() override;
 
+      virtual std::shared_ptr< abstract_backend > clone() const override;
+
    private:
       std::map< key_type, value_type > _map;
       protocol::block_header           _header;

--- a/libraries/state_db/include/koinos/state_db/backends/map/map_backend.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/map/map_backend.hpp
@@ -30,8 +30,10 @@ class map_backend final : public abstract_backend {
       virtual iterator find( const key_type& k ) override;
       virtual iterator lower_bound( const key_type& k ) override;
 
-      virtual const protocol::block_header& block_header() const override;
-      virtual void set_block_header( const protocol::block_header& ) override;
+      virtual void start_write_batch() override;
+      virtual void end_write_batch() override;
+
+      virtual void store_metadata() override;
 
    private:
       std::map< key_type, value_type > _map;

--- a/libraries/state_db/include/koinos/state_db/backends/rocksdb/rocksdb_backend.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/rocksdb/rocksdb_backend.hpp
@@ -47,6 +47,8 @@ class rocksdb_backend final : public abstract_backend {
 
       virtual void store_metadata() override;
 
+      virtual std::shared_ptr< abstract_backend > clone() const override;
+
    private:
       void load_metadata();
 

--- a/libraries/state_db/include/koinos/state_db/backends/rocksdb/rocksdb_backend.hpp
+++ b/libraries/state_db/include/koinos/state_db/backends/rocksdb/rocksdb_backend.hpp
@@ -26,17 +26,8 @@ class rocksdb_backend final : public abstract_backend {
       void close();
       void flush();
 
-      void start_write_batch();
-      void end_write_batch();
-
-      size_type revision() const;
-      void set_revision( size_type rev );
-
-      const crypto::multihash& id() const;
-      void set_id( const crypto::multihash& );
-
-      const crypto::multihash& merkle_root() const;
-      void set_merkle_root( const crypto::multihash& );
+      virtual void start_write_batch() override;
+      virtual void end_write_batch() override;
 
       // Iterators
       virtual iterator begin() override;
@@ -54,10 +45,7 @@ class rocksdb_backend final : public abstract_backend {
       virtual iterator find( const key_type& k ) override;
       virtual iterator lower_bound( const key_type& k ) override;
 
-      virtual const protocol::block_header& block_header() const override;
-      virtual void set_block_header( const protocol::block_header& ) override;
-
-      void store_metadata();
+      virtual void store_metadata() override;
 
    private:
       void load_metadata();
@@ -71,10 +59,6 @@ class rocksdb_backend final : public abstract_backend {
       std::shared_ptr< ::rocksdb::ReadOptions > _ropts;
       mutable std::shared_ptr< object_cache >   _cache;
       size_type                                 _size = 0;
-      size_type                                 _revision = 0;
-      crypto::multihash                         _id;
-      crypto::multihash                         _merkle_root;
-      protocol::block_header                    _header;
 };
 
 } // koinos::state_db::backends::rocksdb

--- a/libraries/state_db/include/koinos/state_db/detail/state_delta.hpp
+++ b/libraries/state_db/include/koinos/state_db/detail/state_delta.hpp
@@ -74,6 +74,7 @@ namespace koinos::state_db::detail {
          const protocol::block_header& block_header() const;
 
          std::shared_ptr< state_delta > make_child( const state_node_id& id = state_node_id(), const protocol::block_header& header = protocol::block_header() );
+         std::shared_ptr< state_delta > clone( const state_node_id& id, const protocol::block_header& header );
 
          const std::shared_ptr< backend_type > backend() const;
 

--- a/libraries/state_db/include/koinos/state_db/detail/state_delta.hpp
+++ b/libraries/state_db/include/koinos/state_db/detail/state_delta.hpp
@@ -40,7 +40,7 @@ namespace koinos::state_db::detail {
 
       public:
          state_delta() = default;
-         state_delta( const std::filesystem::path& p );
+         state_delta( const std::optional< std::filesystem::path >& p );
          ~state_delta() = default;
 
          void put( const key_type& k, const value_type& v );

--- a/libraries/state_db/include/koinos/state_db/state_db.hpp
+++ b/libraries/state_db/include/koinos/state_db/state_db.hpp
@@ -275,6 +275,13 @@ class database final
       state_node_ptr create_writable_node( const state_node_id& parent_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock );
 
       /**
+       * Clone a node with a new id and block header.
+       *
+       * Cannot clone root.
+       */
+      state_node_ptr clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock );
+
+      /**
        * Finalize a node. The node will no longer be writable.
        */
       void finalize_node( const state_node_id& node_id, const shared_lock_ptr& lock );

--- a/libraries/state_db/include/koinos/state_db/state_db.hpp
+++ b/libraries/state_db/include/koinos/state_db/state_db.hpp
@@ -342,9 +342,17 @@ class database final
        * Get and return a vector of all fork heads.
        *
        * Fork heads are any finalized nodes that do
-       * not have children.
+       * not have finalized children.
        */
       std::vector< state_node_ptr > get_fork_heads( const shared_lock_ptr& lock ) const;
+
+      /**
+       * Get and return a vector of all fork heads.
+       *
+       * Fork heads are any finalized nodes that do
+       * not have finalized children.
+       */
+      std::vector< state_node_ptr > get_fork_heads( const unique_lock_ptr& lock ) const;
 
       /**
        * Get and return the current "root" node.

--- a/libraries/state_db/include/koinos/state_db/state_db.hpp
+++ b/libraries/state_db/include/koinos/state_db/state_db.hpp
@@ -210,7 +210,7 @@ class database final
       /**
        * Open the database.
        */
-      void open( const std::filesystem::path& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock );
+      void open( const std::optional< std::filesystem::path >& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock );
 
       /**
        * Close the database.

--- a/libraries/state_db/include/koinos/state_db/state_db.hpp
+++ b/libraries/state_db/include/koinos/state_db/state_db.hpp
@@ -237,6 +237,7 @@ class database final
        * unique lock.
        */
       state_node_ptr get_node_at_revision( uint64_t revision, const state_node_id& child_id, const unique_lock_ptr& lock ) const;
+      state_node_ptr get_node_at_revision( uint64_t revision, const unique_lock_ptr& lock ) const;
 
       /**
        * Get the state_node for the given state_node_id.
@@ -275,11 +276,45 @@ class database final
       state_node_ptr create_writable_node( const state_node_id& parent_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock );
 
       /**
+       * Create a writable state_node.
+       *
+       * - If parent_id refers to a writable node, fail.
+       * - Otherwise, return a new writable node.
+       * - Writing to the returned node will not modify the parent node.
+       *
+       * If the parent is subsequently discarded, database preserves
+       * as much of the parent's state storage as necessary to continue
+       * to serve queries on any (non-discarded) children.  A discarded
+       * parent node's state may internally be merged into a child's
+       * state storage area, allowing the parent's state storage area
+       * to be freed.  This merge may occur immediately, or it may be
+       * deferred or parallelized.
+       *
+       * WARNING: The state node returned does not have an internal lock. The caller
+       * must be careful to ensure internal consistency. Best practice is to not
+       * share this node with a parallel thread and to reset it before releasing the
+       * unique lock.
+       */
+      state_node_ptr create_writable_node( const state_node_id& parent_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock );
+
+      /**
        * Clone a node with a new id and block header.
        *
-       * Cannot clone root.
+       * Cannot clone a finalized node.
        */
       state_node_ptr clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock );
+
+      /**
+       * Clone a node with a new id and block header.
+       *
+       * Cannot clone a finalized node.
+       *
+       * WARNING: The state node returned does not have an internal lock. The caller
+       * must be careful to ensure internal consistency. Best practice is to not
+       * share this node with a parallel thread and to reset it before releasing the
+       * unique lock.
+       */
+      state_node_ptr clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock );
 
       /**
        * Finalize a node. The node will no longer be writable.
@@ -301,6 +336,17 @@ class database final
        * current head node to be delted.
        */
       void discard_node( const state_node_id& node_id, const shared_lock_ptr& lock );
+
+      /**
+       * Discard the node, it can no longer be used.
+       *
+       * If the node has any children, they too will be deleted because
+       * there will no longer exist a path from root to those nodes.
+       *
+       * This will fail if the node you are deleting would cause the
+       * current head node to be delted.
+       */
+      void discard_node( const state_node_id& node_id, const unique_lock_ptr& lock );
 
       /**
        * Squash the node in to the root state, committing it.
@@ -351,6 +397,11 @@ class database final
        *
        * Fork heads are any finalized nodes that do
        * not have finalized children.
+       *
+       * WARNING: The state nodes returned does not have an internal lock. The caller
+       * must be careful to ensure internal consistency. Best practice is to not
+       * share this node with a parallel thread and to reset it before releasing the
+       * unique lock.
        */
       std::vector< state_node_ptr > get_fork_heads( const unique_lock_ptr& lock ) const;
 

--- a/libraries/state_db/state_db.cpp
+++ b/libraries/state_db/state_db.cpp
@@ -109,8 +109,8 @@ class database_impl final
       bool verify_shared_lock( const shared_lock_ptr& lock ) const;
       bool verify_unique_lock( const unique_lock_ptr& lock ) const;
 
-      void open( const std::filesystem::path& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock );
-      void open_lockless( const std::filesystem::path& p, genesis_init_function init, state_node_comparator_function comp );
+      void open( const std::optional< std::filesystem::path >& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock );
+      void open_lockless( const std::optional< std::filesystem::path >& p, genesis_init_function init, state_node_comparator_function comp );
       void close( const unique_lock_ptr& lock );
       void close_lockless();
 
@@ -137,7 +137,7 @@ class database_impl final
 
       bool is_open() const;
 
-      std::filesystem::path                      _path;
+      std::optional< std::filesystem::path >     _path;
       genesis_init_function                      _init_func = nullptr;
       state_node_comparator_function             _comp = nullptr;
 
@@ -214,7 +214,7 @@ void database_impl::reset( const unique_lock_ptr& lock )
    open_lockless( _path, _init_func, _comp );
 }
 
-void database_impl::open( const std::filesystem::path& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock )
+void database_impl::open( const std::optional< std::filesystem::path >& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock )
 {
    KOINOS_ASSERT( verify_unique_lock( lock ), illegal_argument, "database is not properly locked" );
    std::lock_guard< std::timed_mutex > index_lock( _index_mutex );
@@ -222,7 +222,7 @@ void database_impl::open( const std::filesystem::path& p, genesis_init_function 
    open_lockless( p, init, comp );
 }
 
-void database_impl::open_lockless( const std::filesystem::path& p, genesis_init_function init, state_node_comparator_function comp )
+void database_impl::open_lockless( const std::optional< std::filesystem::path >& p, genesis_init_function init, state_node_comparator_function comp )
 {
    auto root = std::make_shared< state_node >();
    root->_impl->_state = std::make_shared< state_delta >( p );
@@ -1032,7 +1032,7 @@ unique_lock_ptr database::get_unique_lock() const
    return impl->get_unique_lock();
 }
 
-void database::open( const std::filesystem::path& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock )
+void database::open( const std::optional< std::filesystem::path >& p, genesis_init_function init, state_node_comparator_function comp, const unique_lock_ptr& lock )
 {
    impl->open( p, init, comp, lock ? lock : get_unique_lock() );
 }

--- a/libraries/state_db/state_db.cpp
+++ b/libraries/state_db/state_db.cpp
@@ -121,7 +121,9 @@ class database_impl final
       state_node_ptr get_node( const state_node_id& node_id, const unique_lock_ptr& lock ) const;
       state_node_ptr get_node_lockless( const state_node_id& node_id ) const;
       state_node_ptr create_writable_node( const state_node_id& parent_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock );
+      state_node_ptr create_writable_node( const state_node_id& parent_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock );
       state_node_ptr clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock );
+      state_node_ptr clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock );
       void finalize_node( const state_node_id& node, const shared_lock_ptr& lock );
       void finalize_node( const state_node_id& node, const unique_lock_ptr& lock );
       void discard_node( const state_node_id& node, const std::unordered_set< state_node_id >& whitelist, const shared_lock_ptr& lock );
@@ -419,6 +421,49 @@ state_node_ptr database_impl::create_writable_node( const state_node_id& parent_
    return state_node_ptr();
 }
 
+state_node_ptr database_impl::create_writable_node( const state_node_id& parent_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock )
+{
+   KOINOS_ASSERT( verify_unique_lock( lock ), illegal_argument, "database is not properly locked" );;
+
+   // Needs to be configurable
+   auto timeout = std::chrono::system_clock::now() + std::chrono::seconds( 1 );
+
+   state_node_ptr parent_state = get_node( parent_id, lock );
+
+   if ( parent_state )
+   {
+      std::unique_lock< std::timed_mutex > cv_lock( parent_state->_impl->_state->cv_mutex(), timeout );
+
+      // We need to own the lock
+      if ( cv_lock.owns_lock() )
+      {
+         // Check if the node is finalized
+         bool is_finalized = parent_state->is_finalized();
+
+         // If the node is finalized, try to wait for the node to be finalized
+         if ( !is_finalized && parent_state->_impl->_state->cv().wait_until( cv_lock, timeout ) == std::cv_status::no_timeout )
+            is_finalized = parent_state->is_finalized();
+
+         // Finally, if the node is finalized, we can create a new writable node with the desired parent
+         if ( is_finalized )
+         {
+            auto node = std::make_shared< state_node >();
+            node->_impl->_state = parent_state->_impl->_state->make_child( new_id, header );
+
+            std::unique_lock< std::timed_mutex > index_lock( _index_mutex, timeout );
+
+            // Ensure the parent node still exists in the index and then insert the child node
+            if ( index_lock.owns_lock() && _index.find( parent_id ) != _index.end() && _index.insert( node->_impl->_state ).second )
+            {
+               return node;
+            }
+         }
+      }
+   }
+
+   return state_node_ptr();
+}
+
 state_node_ptr database_impl::clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock )
 {
    KOINOS_ASSERT( verify_shared_lock( lock ), illegal_argument, "database is not properly locked" );
@@ -435,6 +480,27 @@ state_node_ptr database_impl::clone_node( const state_node_id& node_id, const st
    if ( _index.insert( new_node->_impl->_state ).second )
    {
       new_node->_impl->_lock = lock;
+      return new_node;
+   }
+
+   return state_node_ptr();
+}
+
+state_node_ptr database_impl::clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock )
+{
+   KOINOS_ASSERT( verify_unique_lock( lock ), illegal_argument, "database is not properly locked" );
+   std::lock_guard< std::timed_mutex > index_lock( _index_mutex );
+   KOINOS_ASSERT( is_open(), database_not_open, "database is not open" );
+
+   auto node = get_node_lockless( node_id );
+   KOINOS_ASSERT( node, illegal_argument, "node ${n} not found.", ("n", node_id) );
+   KOINOS_ASSERT( !node->is_finalized(), illegal_argument, "cannot clone finalized node" );
+
+   auto new_node = std::make_shared< state_node >();
+   new_node->_impl->_state = node->_impl->_state->clone( new_id, header );
+
+   if ( _index.insert( new_node->_impl->_state ).second )
+   {
       return new_node;
    }
 
@@ -1106,6 +1172,12 @@ state_node_ptr database::get_node_at_revision( uint64_t revision, const state_no
    return impl->get_node_at_revision( revision, child_id, lock );
 }
 
+state_node_ptr database::get_node_at_revision( uint64_t revision, const unique_lock_ptr& lock ) const
+{
+   static const state_node_id null_id;
+   return impl->get_node_at_revision( revision, null_id, lock );
+}
+
 state_node_ptr database::get_node( const state_node_id& node_id, const shared_lock_ptr& lock ) const
 {
    return impl->get_node( node_id, lock );
@@ -1121,7 +1193,17 @@ state_node_ptr database::create_writable_node( const state_node_id& parent_id, c
    return impl->create_writable_node( parent_id, new_id, header, lock );
 }
 
+state_node_ptr database::create_writable_node( const state_node_id& parent_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock )
+{
+   return impl->create_writable_node( parent_id, new_id, header, lock );
+}
+
 state_node_ptr database::clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const shared_lock_ptr& lock )
+{
+   return impl->clone_node( node_id, new_id, header, lock );
+}
+
+state_node_ptr database::clone_node( const state_node_id& node_id, const state_node_id& new_id, const protocol::block_header& header, const unique_lock_ptr& lock )
 {
    return impl->clone_node( node_id, new_id, header, lock );
 }

--- a/tests/tests/state_db_test.cpp
+++ b/tests/tests/state_db_test.cpp
@@ -810,7 +810,7 @@ BOOST_AUTO_TEST_CASE( rocksdb_backend_test )
    BOOST_CHECK_THROW( backend.lower_bound( "foo" ), koinos::exception );
    BOOST_CHECK_THROW( backend.flush(), koinos::exception );
    BOOST_CHECK( backend.revision() == 0 );
-   BOOST_CHECK( backend.id() == koinos::crypto::multihash() );
+   BOOST_CHECK( backend.id() == koinos::crypto::multihash::zero( koinos::crypto::multicodec::sha2_256 ) );
 
    std::filesystem::create_directory( temp );
    backend.open( temp );

--- a/tests/tests/state_db_test.cpp
+++ b/tests/tests/state_db_test.cpp
@@ -809,10 +809,8 @@ BOOST_AUTO_TEST_CASE( rocksdb_backend_test )
    BOOST_CHECK_THROW( backend.find( "foo" ), koinos::exception );
    BOOST_CHECK_THROW( backend.lower_bound( "foo" ), koinos::exception );
    BOOST_CHECK_THROW( backend.flush(), koinos::exception );
-   BOOST_CHECK_THROW( backend.revision(), koinos::exception );
-   BOOST_CHECK_THROW( backend.set_revision( 1 ), koinos::exception );
-   BOOST_CHECK_THROW( backend.id(), koinos::exception );
-   BOOST_CHECK_THROW( backend.set_id( koinos::crypto::multihash::zero( koinos::crypto::multicodec::sha2_256 ) ), koinos::exception );
+   BOOST_CHECK( backend.revision() == 0 );
+   BOOST_CHECK( backend.id() == koinos::crypto::multihash() );
 
    std::filesystem::create_directory( temp );
    backend.open( temp );


### PR DESCRIPTION
Resolves #9

## Brief description

Allows state_db root node to be backed by a `std::map`, instead of RocksDB, enabling full state_db transience.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
$ ./tests/koinos_state_db_tests -l message               
Running 12 test cases...
Creating object
Modifying object
Erasing object
Basic fork tests on state_db
Test commit
Test discard
Check duplicate node creation
Check failed linking
Test minority fork
Creating object on transient state node
Closing and opening database
Creating object on committed state node
Closing and opening database
Resetting database
Creating object
Creating anonymous state node
Modifying object
Deleting anonymous node
Creating anonymous state node
Modifying object
Committing anonymous node
Test default FIFO fork resolution
Test block time fork resolution
Test pob fork resolution
Checking persistence when backed by rocksdb
Checking transience when backed by std::map

*** No errors detected
```