### PR TITLE
Add fork resolution algorithm to the library

### DIFF
--- a/libraries/state_db/include/koinos/state_db/detail/merge_iterator.hpp
+++ b/libraries/state_db/include/koinos/state_db/detail/merge_iterator.hpp
@@ -130,7 +130,7 @@ class merge_iterator :
       {
          bool dirty = false;
 
-         for( int i = _delta_deque.size() - 1; itr->revision < _delta_deque[i]->revision() && !dirty; --i )
+         for ( auto i = _delta_deque.size() - 1; itr->revision < _delta_deque[i]->revision() && !dirty; --i )
          {
             dirty = _delta_deque[i]->is_modified( itr->itr.key() );
          }

--- a/libraries/state_db/include/koinos/state_db/state_db.hpp
+++ b/libraries/state_db/include/koinos/state_db/state_db.hpp
@@ -29,6 +29,13 @@ class anonymous_state_node;
 using abstract_state_node_ptr = std::shared_ptr< abstract_state_node >;
 using anonymous_state_node_ptr = std::shared_ptr< anonymous_state_node >;
 
+enum class fork_resolution_algorithm
+{
+   fifo,
+   block_time,
+   pob
+};
+
 /**
  * Allows querying the database at a particular checkpoint.
  */
@@ -206,6 +213,11 @@ class database final
       shared_lock_ptr get_shared_lock() const;
 
       unique_lock_ptr get_unique_lock() const;
+
+      /**
+       * Open the database.
+       */
+      void open( const std::optional< std::filesystem::path >& p, genesis_init_function init, fork_resolution_algorithm algo, const unique_lock_ptr& lock );
 
       /**
        * Open the database.

--- a/tests/tests/state_db_test.cpp
+++ b/tests/tests/state_db_test.cpp
@@ -48,7 +48,7 @@ struct state_db_fixture
       temp = std::filesystem::temp_directory_path() / util::random_alphanumeric( 8 );
       std::filesystem::create_directory( temp );
 
-      db.open( temp, [&]( state_db::state_node_ptr root ){}, &state_db::fifo_comparator, db.get_unique_lock() );
+      db.open( temp, [&]( state_db::state_node_ptr root ){}, fork_resolution_algorithm::fifo, db.get_unique_lock() );
    }
 
    ~state_db_fixture()


### PR DESCRIPTION
Resolves #18.

## Brief description
Adds `enum class fork_resolution_algorithm` and an overloaded `open()` function that accepts it as parameter and translate it to a comparator function.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ./tests/Debug/koinos_state_db_tests -l message
Running 13 test cases...
Creating object
Modifying object
Erasing object
Basic fork tests on state_db
Test commit
Test discard
Check duplicate node creation
Check failed linking
Test minority fork
Creating object on transient state node
Closing and opening database
Creating object on committed state node
Closing and opening database
Resetting database
Creating object
Creating anonymous state node
Modifying object
Deleting anonymous node
Creating anonymous state node
Modifying object
Committing anonymous node
Test default FIFO fork resolution
Test block time fork resolution
Test pob fork resolution
Checking persistence when backed by rocksdb
Checking transience when backed by std::map
Check clone of un-finalized node
Checking clone of a finalized node

*** No errors detected
```
