### PR TITLE
Add operator overload for less than `object_space` to `state_db`

### DIFF
--- a/libraries/state_db/state_db.cpp
+++ b/libraries/state_db/state_db.cpp
@@ -35,6 +35,29 @@ namespace koinos::chain {
          && lhs.zone() == rhs.zone()
          && lhs.id() == rhs.id();
    }
+
+   bool operator<( const object_space& lhs, const object_space& rhs )
+   {
+      if ( lhs.system() < rhs.system() )
+      {
+         return true;
+      }
+      else if ( lhs.system() > rhs.system() )
+      {
+         return false;
+      }
+
+      if ( lhs.zone() < rhs.zone() )
+      {
+         return true;
+      }
+      else if ( lhs.system() > rhs.system() )
+      {
+         return false;
+      }
+
+      return lhs.id() < rhs.id();
+   }
 }
 
 namespace koinos::state_db {


### PR DESCRIPTION
Resolves #21.

## Brief description
Add operator overload for less than `object_space` to `state_db`.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

```console
❯ ./tests/Debug/koinos_state_db_tests -l message
Running 14 test cases...
Creating object
Modifying object
Erasing object
Basic fork tests on state_db
Test commit
Test discard
Check duplicate node creation
Check failed linking
Test minority fork
Creating object on transient state node
Closing and opening database
Creating object on committed state node
Closing and opening database
Resetting database
Creating object
Creating anonymous state node
Modifying object
Deleting anonymous node
Creating anonymous state node
Modifying object
Committing anonymous node
Test default FIFO fork resolution
Test block time fork resolution
Test pob fork resolution
Checking persistence when backed by rocksdb
Checking transience when backed by std::map
Check clone of un-finalized node
Checking clone of a finalized node
Create state nodes
Check all state nodes
Commit 1a
Check all state nodes

*** No errors detected
```
