### PR TITLE
Do not make state-db-exception a child of reversion_exception

### DIFF
--- a/include/koinos/state_db/state_db_types.hpp
+++ b/include/koinos/state_db/state_db_types.hpp
@@ -14,7 +14,7 @@ using object_space  = chain::object_space;
 using object_key    = std::string;
 using object_value  = std::string;
 
-KOINOS_DECLARE_DERIVED_EXCEPTION( state_db_exception, chain::reversion_exception );
+KOINOS_DECLARE_EXCEPTION( state_db_exception )
 
 KOINOS_DECLARE_DERIVED_EXCEPTION( database_not_open, state_db_exception );
 


### PR DESCRIPTION
## Brief description

Make `state_db_exception` not a child of `chain::reversion_exception`.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
❯ ctest 
Test project /home/michael/dev/koinos-state-db-cpp/build/tests
      Start  1: state_db_tests-state_db_tests/basic_test
 1/15 Test  #1: state_db_tests-state_db_tests/basic_test ..................   Passed    1.04 sec
      Start  2: state_db_tests-state_db_tests/fork_tests
 2/15 Test  #2: state_db_tests-state_db_tests/fork_tests ..................   Passed    0.03 sec
      Start  3: state_db_tests-state_db_tests/merge_iterator
 3/15 Test  #3: state_db_tests-state_db_tests/merge_iterator ..............   Passed    0.05 sec
      Start  4: state_db_tests-state_db_tests/reset_test
 4/15 Test  #4: state_db_tests-state_db_tests/reset_test ..................   Passed    0.06 sec
      Start  5: state_db_tests-state_db_tests/anonymous_node_test
 5/15 Test  #5: state_db_tests-state_db_tests/anonymous_node_test .........   Passed    0.02 sec
      Start  6: state_db_tests-state_db_tests/merkle_root_test
 6/15 Test  #6: state_db_tests-state_db_tests/merkle_root_test ............   Passed    0.03 sec
      Start  7: state_db_tests-state_db_tests/get_delta_entries_test
 7/15 Test  #7: state_db_tests-state_db_tests/get_delta_entries_test ......   Passed    0.03 sec
      Start  8: state_db_tests-state_db_tests/rocksdb_backend_test
 8/15 Test  #8: state_db_tests-state_db_tests/rocksdb_backend_test ........   Passed    0.04 sec
      Start  9: state_db_tests-state_db_tests/rocksdb_object_cache_test
 9/15 Test  #9: state_db_tests-state_db_tests/rocksdb_object_cache_test ...   Passed    0.02 sec
      Start 10: state_db_tests-state_db_tests/map_backend_test
10/15 Test #10: state_db_tests-state_db_tests/map_backend_test ............   Passed    0.03 sec
      Start 11: state_db_tests-state_db_tests/fork_resolution
11/15 Test #11: state_db_tests-state_db_tests/fork_resolution .............   Passed    0.06 sec
      Start 12: state_db_tests-state_db_tests/restart_cache
12/15 Test #12: state_db_tests-state_db_tests/restart_cache ...............   Passed    0.03 sec
      Start 13: state_db_tests-state_db_tests/persistence
13/15 Test #13: state_db_tests-state_db_tests/persistence .................   Passed    0.04 sec
      Start 14: state_db_tests-state_db_tests/clone_node
14/15 Test #14: state_db_tests-state_db_tests/clone_node ..................   Passed    0.03 sec
      Start 15: state_db_tests-state_db_tests/get_all_nodes
15/15 Test #15: state_db_tests-state_db_tests/get_all_nodes ...............   Passed    0.03 sec

100% tests passed, 0 tests failed out of 15

Total Test time (real) =   1.54 sec
```
