### PR TITLE
Add preserve-tombstone removal and pending merkle root for receipt delta replay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_MakeAvailable(koinos_cmake)
 include("${koinos_cmake_SOURCE_DIR}/Koinos.cmake")
 
 project(koinos_state_db
-  VERSION 1.1.2
+  VERSION 1.2.0
   DESCRIPTION "The Koinos statedb library"
   LANGUAGES CXX C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_MakeAvailable(koinos_cmake)
 include("${koinos_cmake_SOURCE_DIR}/Koinos.cmake")
 
 project(koinos_state_db
-  VERSION 1.2.0
+  VERSION 1.2.1
   DESCRIPTION "The Koinos statedb library"
   LANGUAGES CXX C)
 

--- a/include/koinos/state_db/state_db.hpp
+++ b/include/koinos/state_db/state_db.hpp
@@ -109,6 +109,15 @@ public:
   crypto::multihash merkle_root() const;
 
   /**
+   * Return the merkle root of writes on this state node without requiring finalization.
+   *
+   * Unlike merkle_root(), the value is computed fresh on every call and never cached,
+   * so it remains correct if the node is mutated afterwards. Intended for inspecting
+   * the pending root of a writable node while replaying serialized state deltas.
+   */
+  crypto::multihash pending_merkle_root() const;
+
+  /**
    * Returns the state delta entries associated with this state node
    */
   std::vector< protocol::state_delta_entry > get_delta_entries() const;

--- a/include/koinos/state_db/state_db.hpp
+++ b/include/koinos/state_db/state_db.hpp
@@ -91,6 +91,14 @@ public:
   int64_t remove_object( const object_space& space, const object_key& key );
 
   /**
+   * Remove an object while preserving the delete tombstone even when the object is absent.
+   *
+   * This is intended only for replaying serialized historical state deltas. Normal state
+   * mutation should use remove_object().
+   */
+  int64_t remove_object_preserve_tombstone( const object_space& space, const object_key& key );
+
+  /**
    * Return true if the node is writable.
    */
   bool is_finalized() const;

--- a/src/koinos/state_db/state_db.cpp
+++ b/src/koinos/state_db/state_db.cpp
@@ -102,7 +102,7 @@ public:
   std::pair< const object_value*, const object_key > get_prev_object( const object_space& space,
                                                                       const object_key& key ) const;
   int64_t put_object( const object_space& space, const object_key& key, const object_value* val );
-  int64_t remove_object( const object_space& space, const object_key& key );
+  int64_t remove_object( const object_space& space, const object_key& key, bool preserve_tombstone = false );
   crypto::multihash merkle_root() const;
   std::vector< protocol::state_delta_entry > get_delta_entries() const;
 
@@ -1086,7 +1086,7 @@ int64_t state_node_impl::put_object( const object_space& space, const object_key
   return bytes_used;
 }
 
-int64_t state_node_impl::remove_object( const object_space& space, const object_key& key )
+int64_t state_node_impl::remove_object( const object_space& space, const object_key& key, bool preserve_tombstone )
 {
   KOINOS_ASSERT( !_state->is_finalized(), node_finalized, "cannot write to a finalized node" );
 
@@ -1104,7 +1104,7 @@ int64_t state_node_impl::remove_object( const object_space& space, const object_
     bytes_used -= key_string.size();
   }
 
-  _state->erase( key_string );
+  _state->erase( key_string, preserve_tombstone );
 
   return bytes_used;
 }
@@ -1152,6 +1152,11 @@ int64_t abstract_state_node::put_object( const object_space& space, const object
 int64_t abstract_state_node::remove_object( const object_space& space, const object_key& key )
 {
   return _impl->remove_object( space, key );
+}
+
+int64_t abstract_state_node::remove_object_preserve_tombstone( const object_space& space, const object_key& key )
+{
+  return _impl->remove_object( space, key, true );
 }
 
 bool abstract_state_node::is_finalized() const

--- a/src/koinos/state_db/state_db.cpp
+++ b/src/koinos/state_db/state_db.cpp
@@ -104,6 +104,7 @@ public:
   int64_t put_object( const object_space& space, const object_key& key, const object_value* val );
   int64_t remove_object( const object_space& space, const object_key& key, bool preserve_tombstone = false );
   crypto::multihash merkle_root() const;
+  crypto::multihash pending_merkle_root() const;
   std::vector< protocol::state_delta_entry > get_delta_entries() const;
 
   state_delta_ptr _state;
@@ -1114,6 +1115,11 @@ crypto::multihash state_node_impl::merkle_root() const
   return _state->merkle_root();
 }
 
+crypto::multihash state_node_impl::pending_merkle_root() const
+{
+  return _state->calculate_merkle_root();
+}
+
 std::vector< protocol::state_delta_entry > state_node_impl::get_delta_entries() const
 {
   return _state->get_delta_entries();
@@ -1168,6 +1174,11 @@ crypto::multihash abstract_state_node::merkle_root() const
 {
   KOINOS_ASSERT( is_finalized(), koinos::exception, "node must be finalized to calculate merkle root" );
   return _impl->merkle_root();
+}
+
+crypto::multihash abstract_state_node::pending_merkle_root() const
+{
+  return _impl->pending_merkle_root();
 }
 
 std::vector< protocol::state_delta_entry > abstract_state_node::get_delta_entries() const

--- a/src/koinos/state_db/state_delta.cpp
+++ b/src/koinos/state_db/state_delta.cpp
@@ -209,34 +209,43 @@ crypto::multihash state_delta::merkle_root() const
 {
   if( !_merkle_root )
   {
-    std::vector< std::string > object_keys;
-    object_keys.reserve( _backend->size() + _removed_objects.size() );
-    for( auto itr = _backend->begin(); itr != _backend->end(); ++itr )
-    {
-      object_keys.push_back( itr.key() );
-    }
-
-    for( const auto& removed: _removed_objects )
-    {
-      object_keys.push_back( removed );
-    }
-
-    std::sort( object_keys.begin(), object_keys.end() );
-
-    std::vector< crypto::multihash > merkle_leafs;
-    merkle_leafs.reserve( object_keys.size() * 2 );
-
-    for( const auto& key: object_keys )
-    {
-      merkle_leafs.emplace_back( crypto::hash( crypto::multicodec::sha2_256, key ) );
-      auto val_ptr = _backend->get( key );
-      merkle_leafs.emplace_back( crypto::hash( crypto::multicodec::sha2_256, val_ptr ? *val_ptr : std::string() ) );
-    }
-
-    _merkle_root = crypto::merkle_tree( crypto::multicodec::sha2_256, merkle_leafs ).root()->hash();
+    _merkle_root = calculate_merkle_root();
   }
 
   return *_merkle_root;
+}
+
+// Computes the delta merkle root without reading or populating the cached value.
+// Mutations do not invalidate _merkle_root, so callers that may mutate the delta
+// afterwards (pending root inspection of a writable node) must use this instead
+// of merkle_root().
+crypto::multihash state_delta::calculate_merkle_root() const
+{
+  std::vector< std::string > object_keys;
+  object_keys.reserve( _backend->size() + _removed_objects.size() );
+  for( auto itr = _backend->begin(); itr != _backend->end(); ++itr )
+  {
+    object_keys.push_back( itr.key() );
+  }
+
+  for( const auto& removed: _removed_objects )
+  {
+    object_keys.push_back( removed );
+  }
+
+  std::sort( object_keys.begin(), object_keys.end() );
+
+  std::vector< crypto::multihash > merkle_leafs;
+  merkle_leafs.reserve( object_keys.size() * 2 );
+
+  for( const auto& key: object_keys )
+  {
+    merkle_leafs.emplace_back( crypto::hash( crypto::multicodec::sha2_256, key ) );
+    auto val_ptr = _backend->get( key );
+    merkle_leafs.emplace_back( crypto::hash( crypto::multicodec::sha2_256, val_ptr ? *val_ptr : std::string() ) );
+  }
+
+  return crypto::merkle_tree( crypto::multicodec::sha2_256, merkle_leafs ).root()->hash();
 }
 
 const protocol::block_header& state_delta::block_header() const

--- a/src/koinos/state_db/state_delta.cpp
+++ b/src/koinos/state_db/state_delta.cpp
@@ -30,9 +30,9 @@ void state_delta::put( const key_type& k, const value_type& v )
   _backend->put( k, v );
 }
 
-void state_delta::erase( const key_type& k )
+void state_delta::erase( const key_type& k, bool preserve_tombstone )
 {
-  if( find( k ) )
+  if( find( k ) || preserve_tombstone )
   {
     _backend->erase( k );
     _removed_objects.insert( k );

--- a/src/koinos/state_db/state_delta.hpp
+++ b/src/koinos/state_db/state_delta.hpp
@@ -67,6 +67,7 @@ public:
   std::timed_mutex& cv_mutex();
 
   crypto::multihash merkle_root() const;
+  crypto::multihash calculate_merkle_root() const;
   std::vector< protocol::state_delta_entry > get_delta_entries() const;
 
   const state_node_id& id() const;

--- a/src/koinos/state_db/state_delta.hpp
+++ b/src/koinos/state_db/state_delta.hpp
@@ -44,7 +44,7 @@ public:
   ~state_delta() = default;
 
   void put( const key_type& k, const value_type& v );
-  void erase( const key_type& k );
+  void erase( const key_type& k, bool preserve_tombstone = false );
   const value_type* find( const key_type& key ) const;
 
   void squash();

--- a/tests/state_db_test.cpp
+++ b/tests/state_db_test.cpp
@@ -931,6 +931,116 @@ BOOST_AUTO_TEST_CASE( get_delta_entries_test )
   KOINOS_CATCH_LOG_AND_RETHROW( info )
 }
 
+BOOST_AUTO_TEST_CASE( preserve_tombstone_test )
+{
+  try
+  {
+    auto shared_db_lock = db.get_shared_lock();
+
+    object_space space;
+    std::string a_key = "a";
+    std::string a_val = "alice";
+    std::string b_key = "b";
+    std::string b_val = "bob";
+    std::string c_key = "c";
+    std::string c_val = "charlie";
+
+    // Parent state contains only A
+    auto state_1_id = crypto::hash( crypto::multicodec::sha2_256, 1 );
+    auto state_1    = db.create_writable_node( db.get_head( shared_db_lock )->id(),
+                                            state_1_id,
+                                            protocol::block_header(),
+                                            shared_db_lock );
+
+    state_1->put_object( space, a_key, &a_val );
+    db.finalize_node( state_1_id, shared_db_lock );
+
+    // Normal semantics: removing an absent key is a no-op and must not
+    // create a delta entry (contract execution must not invent state changes)
+    auto noop_id = crypto::hash( crypto::multicodec::sha2_256, 2 );
+    auto noop    = db.create_writable_node( state_1_id, noop_id, protocol::block_header(), shared_db_lock );
+
+    noop->remove_object( space, b_key );
+    BOOST_CHECK_EQUAL( 0, noop->get_delta_entries().size() );
+
+    // Preserved semantics: removing an absent key records the tombstone
+    // as a value-less delta entry (receipt replay of a committed delta)
+    auto tombstone_id = crypto::hash( crypto::multicodec::sha2_256, 3 );
+    auto tombstone = db.create_writable_node( state_1_id, tombstone_id, protocol::block_header(), shared_db_lock );
+
+    tombstone->remove_object_preserve_tombstone( space, b_key );
+    auto tombstone_entries = tombstone->get_delta_entries();
+    BOOST_REQUIRE_EQUAL( 1, tombstone_entries.size() );
+    BOOST_CHECK_EQUAL( b_key, tombstone_entries[ 0 ].key() );
+    BOOST_CHECK_EQUAL( false, tombstone_entries[ 0 ].has_value() );
+
+    // The tombstone must contribute to the delta merkle root
+    db.finalize_node( noop_id, shared_db_lock );
+    db.finalize_node( tombstone_id, shared_db_lock );
+    BOOST_CHECK( noop->merkle_root() != tombstone->merkle_root() );
+
+    // Full replay scenario. Execution: remove A, put B, remove B, put C.
+    // The compacted delta is: remove A, remove B, put C. B was created and
+    // removed inside the same delta, so its remove entry references a key
+    // that is absent from the parent state.
+    auto execution_id = crypto::hash( crypto::multicodec::sha2_256, 4 );
+    auto execution = db.create_writable_node( state_1_id, execution_id, protocol::block_header(), shared_db_lock );
+
+    execution->remove_object( space, a_key );
+    execution->put_object( space, b_key, &b_val );
+    execution->remove_object( space, b_key );
+    execution->put_object( space, c_key, &c_val );
+
+    auto execution_entries = execution->get_delta_entries();
+    BOOST_REQUIRE_EQUAL( 3, execution_entries.size() );
+    BOOST_CHECK_EQUAL( a_key, execution_entries[ 0 ].key() );
+    BOOST_CHECK_EQUAL( false, execution_entries[ 0 ].has_value() );
+    BOOST_CHECK_EQUAL( b_key, execution_entries[ 1 ].key() );
+    BOOST_CHECK_EQUAL( false, execution_entries[ 1 ].has_value() );
+    BOOST_CHECK_EQUAL( c_key, execution_entries[ 2 ].key() );
+    BOOST_CHECK_EQUAL( c_val, execution_entries[ 2 ].value() );
+
+    db.finalize_node( execution_id, shared_db_lock );
+
+    // Replaying the serialized entries with normal remove semantics drops
+    // the absent-key tombstone for B and computes a different merkle root
+    auto normal_replay_id = crypto::hash( crypto::multicodec::sha2_256, 5 );
+    auto normal_replay =
+      db.create_writable_node( state_1_id, normal_replay_id, protocol::block_header(), shared_db_lock );
+
+    for( const auto& entry: execution_entries )
+    {
+      if( entry.has_value() )
+        normal_replay->put_object( space, entry.key(), &entry.value() );
+      else
+        normal_replay->remove_object( space, entry.key() );
+    }
+
+    BOOST_CHECK_EQUAL( 2, normal_replay->get_delta_entries().size() );
+    db.finalize_node( normal_replay_id, shared_db_lock );
+    BOOST_CHECK( execution->merkle_root() != normal_replay->merkle_root() );
+
+    // Replaying with preserved tombstones reproduces the execution delta
+    // and its merkle root exactly
+    auto preserved_replay_id = crypto::hash( crypto::multicodec::sha2_256, 6 );
+    auto preserved_replay =
+      db.create_writable_node( state_1_id, preserved_replay_id, protocol::block_header(), shared_db_lock );
+
+    for( const auto& entry: execution_entries )
+    {
+      if( entry.has_value() )
+        preserved_replay->put_object( space, entry.key(), &entry.value() );
+      else
+        preserved_replay->remove_object_preserve_tombstone( space, entry.key() );
+    }
+
+    BOOST_CHECK_EQUAL( 3, preserved_replay->get_delta_entries().size() );
+    db.finalize_node( preserved_replay_id, shared_db_lock );
+    BOOST_CHECK_EQUAL( execution->merkle_root(), preserved_replay->merkle_root() );
+  }
+  KOINOS_CATCH_LOG_AND_RETHROW( info )
+}
+
 BOOST_AUTO_TEST_CASE( rocksdb_backend_test )
 {
   try

--- a/tests/state_db_test.cpp
+++ b/tests/state_db_test.cpp
@@ -1104,6 +1104,47 @@ BOOST_AUTO_TEST_CASE( preserve_tombstone_test )
   KOINOS_CATCH_LOG_AND_RETHROW( info )
 }
 
+BOOST_AUTO_TEST_CASE( pending_merkle_root_test )
+{
+  try
+  {
+    auto shared_db_lock = db.get_shared_lock();
+
+    object_space space;
+    std::string a_key = "a";
+    std::string a_val = "alice";
+    std::string b_key = "b";
+    std::string b_val = "bob";
+
+    auto state_1_id = crypto::hash( crypto::multicodec::sha2_256, 1 );
+    auto state_1    = db.create_writable_node( db.get_head( shared_db_lock )->id(),
+                                            state_1_id,
+                                            protocol::block_header(),
+                                            shared_db_lock );
+
+    state_1->put_object( space, a_key, &a_val );
+    state_1->remove_object_preserve_tombstone( space, b_key );
+
+    // The pending root is available on a writable node while merkle_root still throws
+    auto pending_before = state_1->pending_merkle_root();
+    BOOST_CHECK_THROW( state_1->merkle_root(), koinos::exception );
+
+    // Mutating after a pending root computation must be reflected in later
+    // computations - the pending call must not populate the cached root
+    std::string c_key = "c";
+    std::string c_val = "charlie";
+    state_1->put_object( space, c_key, &c_val );
+
+    auto pending_after = state_1->pending_merkle_root();
+    BOOST_CHECK( pending_before != pending_after );
+
+    db.finalize_node( state_1_id, shared_db_lock );
+    BOOST_CHECK_EQUAL( pending_after, state_1->merkle_root() );
+    BOOST_CHECK_EQUAL( pending_after, state_1->pending_merkle_root() );
+  }
+  KOINOS_CATCH_LOG_AND_RETHROW( info )
+}
+
 BOOST_AUTO_TEST_CASE( rocksdb_backend_test )
 {
   try

--- a/tests/state_db_test.cpp
+++ b/tests/state_db_test.cpp
@@ -1037,6 +1037,69 @@ BOOST_AUTO_TEST_CASE( preserve_tombstone_test )
     BOOST_CHECK_EQUAL( 3, preserved_replay->get_delta_entries().size() );
     db.finalize_node( preserved_replay_id, shared_db_lock );
     BOOST_CHECK_EQUAL( execution->merkle_root(), preserved_replay->merkle_root() );
+
+    // Removing a key present in the parent state must behave identically
+    // under both semantics: same delta entries, same merkle root
+    auto parity_normal_id = crypto::hash( crypto::multicodec::sha2_256, 7 );
+    auto parity_normal =
+      db.create_writable_node( state_1_id, parity_normal_id, protocol::block_header(), shared_db_lock );
+    parity_normal->remove_object( space, a_key );
+
+    auto parity_preserved_id = crypto::hash( crypto::multicodec::sha2_256, 8 );
+    auto parity_preserved =
+      db.create_writable_node( state_1_id, parity_preserved_id, protocol::block_header(), shared_db_lock );
+    parity_preserved->remove_object_preserve_tombstone( space, a_key );
+
+    auto parity_normal_entries    = parity_normal->get_delta_entries();
+    auto parity_preserved_entries = parity_preserved->get_delta_entries();
+    BOOST_REQUIRE_EQUAL( 1, parity_normal_entries.size() );
+    BOOST_REQUIRE_EQUAL( 1, parity_preserved_entries.size() );
+    BOOST_CHECK_EQUAL( parity_normal_entries[ 0 ].DebugString(), parity_preserved_entries[ 0 ].DebugString() );
+
+    db.finalize_node( parity_normal_id, shared_db_lock );
+    db.finalize_node( parity_preserved_id, shared_db_lock );
+    BOOST_CHECK_EQUAL( parity_normal->merkle_root(), parity_preserved->merkle_root() );
+
+    // A delta of {put X, preserved-remove Y (absent), put Z} must reproduce a
+    // reference merkle root computed by hand from the serialized database keys:
+    // sorted keys, value leaf of the preserved tombstone is the empty string
+    std::string x_key = "x";
+    std::string x_val = "xavier";
+    std::string y_key = "y";
+    std::string z_key = "z";
+    std::string z_val = "zoe";
+
+    auto reference_id = crypto::hash( crypto::multicodec::sha2_256, 9 );
+    auto reference = db.create_writable_node( state_1_id, reference_id, protocol::block_header(), shared_db_lock );
+
+    reference->put_object( space, x_key, &x_val );
+    reference->remove_object_preserve_tombstone( space, y_key );
+    reference->put_object( space, z_key, &z_val );
+
+    chain::database_key x_db_key;
+    *x_db_key.mutable_space() = space;
+    x_db_key.set_key( x_key );
+
+    chain::database_key y_db_key;
+    *y_db_key.mutable_space() = space;
+    y_db_key.set_key( y_key );
+
+    chain::database_key z_db_key;
+    *z_db_key.mutable_space() = space;
+    z_db_key.set_key( z_key );
+
+    std::vector< std::string > reference_leafs;
+    reference_leafs.emplace_back( koinos::util::converter::as< std::string >( x_db_key ) );
+    reference_leafs.push_back( x_val );
+    reference_leafs.emplace_back( koinos::util::converter::as< std::string >( y_db_key ) );
+    reference_leafs.push_back( "" );
+    reference_leafs.emplace_back( koinos::util::converter::as< std::string >( z_db_key ) );
+    reference_leafs.push_back( z_val );
+
+    db.finalize_node( reference_id, shared_db_lock );
+    auto reference_root =
+      koinos::crypto::merkle_tree< std::string >( koinos::crypto::multicodec::sha2_256, reference_leafs ).root()->hash();
+    BOOST_CHECK_EQUAL( reference_root, reference->merkle_root() );
   }
   KOINOS_CATCH_LOG_AND_RETHROW( info )
 }


### PR DESCRIPTION
## Summary

Adds the state-db primitives required to fix the `verify-blocks=false` receipt-delta replay path in koinos-chain (koinos/koinos-chain#860 — the January 2026 "block previous state merkle mismatch" halts):

1. **`erase( k, preserve_tombstone = false )` + `remove_object_preserve_tombstone()`** — record a removal tombstone even when the key is absent from the parent state. A compacted block receipt keeps the remove entry of a key created and removed within the same block; the consensus merkle root includes its tombstone leaf (the key existed at the moment of removal during execution), but replaying that entry with plain `remove_object` is a no-op and silently drops the leaf, so the replayed root diverges from consensus. All existing callers keep the old semantics — live execution must never invent tombstones for absent keys.

2. **`pending_merkle_root()`** — compute a still-writable node's delta merkle root. `merkle_root()` asserts finalization, and its underlying computation caches a value that mutations never invalidate, so an early call would poison later reads. The computation is extracted into `state_delta::calculate_merkle_root()` (never reads or populates the cache); `merkle_root()` remains the caching wrapper. koinos-chain uses this to verify each replayed block's root against the consensus-signed value in the next header **before** finalizing the node — the point where a mismatching block can still be repaired (a finalized head node cannot be discarded).

## Tests

`preserve_tombstone_test` — absent-key erase is a no-op under normal semantics and records the tombstone under preserve semantics; present-key removal is identical under both; a full compacted-delta replay (`remove A, remove transient B, put C`) reproduces the execution root exactly; a hand-computed reference root pins the exact leaf layout (sorted serialized database keys, empty-string value leaf for tombstones).

`pending_merkle_root_test` — available on writable nodes while `merkle_root()` still throws; later mutations are reflected (no cache poisoning); equals `merkle_root()` after finalization.

## Evidence scale

A full-history mainnet audit (37,280,004 blocks, 290,295,679 receipt delta entries) validates that preserve-tombstone replay reproduces the consensus-signed root chain for every block except two known per-block anomalies handled on the chain side (see the companion koinos-chain PR). Analysis and reproduction tooling: [`koinos-one` docs/compatibility](https://github.com/koinos/koinos-one/tree/feat/native-node-version/docs/compatibility).

## Dependencies

None. The companion koinos-chain PR depends on this one (new APIs + a Hunter pin bump after release).
